### PR TITLE
i18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 ## L10n Workflow - WebExtension
 
-Esta WebExtension é uma maneira mais rápida de acessar os sites utilizados para localizar/traduzir os produtos e projetos da Mozilla para o Português do Brasil. Basta clicar no ícone e seu fluxo de trabalho estará pronto!
+This WebExtension is a fast way to access websites used to localize / translate Mozilla products and projects. Just click on the icon and your workflow will be ready!
 
-Este repositório está disponível sob a licença [Mozilla Public License Version 2.0](LICENSE)
+It's licensed under [Mozilla Public License Version 2.0](LICENSE)
 
-### Como testar esta WebExtension
+### How to test this extension
 
-1. Clone este repositório `git clone https://github.com/cynthiapereira/webextension-l10n-workflow.git`
+1. Clone the repository `git clone https://github.com/cynthiapereira/webextension-l10n-workflow.git`
 
-1. Na barra de endereços do Firefox digite `about:debugging`
+1. Type `about:debugging` into the Firefox address bar.
 
-1. Clique em `Load Temporary Add-on`, uma janela de diálogo se abrirá.
+1. Click `Load Temporary Add-on` button, a dialog window will open.
 
-1. No repositório clonado, selecione o arquivo `manifest.json`. O ícone da WebExtension aparecerá na sua barra de ferramentas.
+1. Select `manifest.json` file in the cloned repository. The extension icon will appear on your toolbar.
 
-### Como usar esta WebExtension permanentemente
+### How to install this extension
 
-Instale esta extensão por meio do site [addons.mozilla.org](https://addons.mozilla.org/pt-BR/firefox/addon/l10n-workflow/).
+You can download and install this extension from the [Mozilla Add-ons](https://addons.mozilla.org/firefox/addon/l10n-workflow/) server.
 
-### Como contribuir
+### How to contribute
 
-Possui uma sugestão, dúvida ou encontrou um erro? Por favor, abra uma nova [issue](https://github.com/cynthiapereira/webextension-l10n-workflow/issues/new).
+Have a suggestion, question or found an error? Please open a new [issue](https://github.com/cynthiapereira/webextension-l10n-workflow/issues/new).
 
-### Saiba mais
+### More info
 
-Para saber mais sobre o desenvolvimento de WebExtensions, veja a [esta documentação da Mozilla Developer Network](https://developer.mozilla.org/en-US/Add-ons/WebExtensions) *(em inglês)*.
+To learn more about WebExtensions development, see [the documentation on Mozilla Developer Network](https://developer.mozilla.org/en-US/Add-ons/WebExtensions).
 
-Para saber mais sobre o time de localização/tradução de produtos e projetos da Mozilla no Brasil, leia [esta página da Wiki](https://wiki.mozilla.org/Brasil/L10n).
+To learn more about Mozilla products localization and translation, visit the [Mozilla Localization website](https://l10n.mozilla.org/).

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,78 @@
+{
+  "extensionName": {
+    "message": "L10n Workflow"
+  },
+
+  "extensionDescription": {
+    "message": "Faster way to access the websites used to localize / translate Mozilla products and projects into your language."
+  },
+
+  "optionsLocaleLabel": {
+    "message": "Locale:"
+  },
+
+  "pontoonLinkText": {
+    "message": "Pontoon"
+  },
+
+  "pontoonLinkTooltip": {
+    "message": "Translation tools for Mozilla products and websites"
+  },
+
+  "pontoonTerminologyLinkText": {
+    "message": "Pontoon Terminology"
+  },
+
+  "pontoonTerminologyLinkTooltip": {
+    "message": "Search in Pontoon how an expression has been translated in other strings"
+  },
+
+  "transvisionLinkText": {
+    "message": "Transvision"
+  },
+
+  "transvisionLinkTooltip": {
+    "message": "Tool to search how other l10n teams have translated a string"
+  },
+
+  "glossaryLinkText": {
+    "message": "Glossary"
+  },
+
+  "glossaryLinkTooltip": {
+    "message": "Set of standard terms adopted in translations"
+  },
+
+  "styleGuideLinkText": {
+    "message": "Style Guide"
+  },
+
+  "styleGuideLinkTooltip": {
+    "message": "Guide containing best practices for localization adopted by the team"
+  },
+
+  "cambridgeLinkText": {
+    "message": "Cambridge Dictionary"
+  },
+
+  "cambridgeLinkTooltip": {
+    "message": "Reputed dictionary"
+  },
+
+  "webdashboardLinkText": {
+    "message": "Web Localization Dashboard"
+  },
+
+  "webdashboardLinkTooltip": {
+    "message": "Overview of Mozilla projects translation status"
+  },
+
+  "githubLinkText": {
+    "message": "Github"
+  },
+
+  "githubLinkTooltip": {
+    "message": "Fork me on Github!"
+  }
+}
+

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,0 +1,78 @@
+{
+  "extensionName": {
+    "message": "L10n Workflow"
+  },
+
+  "extensionDescription": {
+    "message": "Uma maneira mais rápida de acessar os sites utilizados para localizar/traduzir os produtos e projetos da Mozilla para o Português do Brasil."
+  },
+
+  "optionsLocaleLabel": {
+    "message": "Locale:"
+  },
+
+  "pontoonLinkText": {
+    "message": "Pontoon"
+  },
+
+  "pontoonLinkTooltip": {
+    "message": "Ferramenta de tradução dos produtos e sites da Mozilla"
+  },
+
+  "pontoonTerminologyLinkText": {
+    "message": "Pontoon Terminology"
+  },
+
+  "pontoonTerminologyLinkTooltip": {
+    "message": "Ferramenta para visualização de como uma expressão foi traduzida em outras strings no Pontoon"
+  },
+
+  "transvisionLinkText": {
+    "message": "Transvision"
+  },
+
+  "transvisionLinkTooltip": {
+    "message": "Ferramenta para visualização de como outros times de l10n traduziram strings"
+  },
+
+  "glossaryLinkText": {
+    "message": "Glossário"
+  },
+
+  "glossaryLinkTooltip": {
+    "message": "Conjunto de termos padrões adotados nas traduções para Português"
+  },
+
+  "styleGuideLinkText": {
+    "message": "Guia de estilos"
+  },
+
+  "styleGuideLinkTooltip": {
+    "message": "Guia de boas práticas de localização adotado pelo time brasileiro"
+  },
+
+  "cambridgeLinkText": {
+    "message": "Cambridge Dictionary"
+  },
+
+  "cambridgeLinkTooltip": {
+    "message": "Renomado dicionário Inglês-Português e Português-Inglês"
+  },
+
+  "webdashboardLinkText": {
+    "message": "Web Localization Dashboard"
+  },
+
+  "webdashboardLinkTooltip": {
+    "message": "Visão geral do status de tradução dos projetos da Mozilla"
+  },
+
+  "githubLinkText": {
+    "message": "Github"
+  },
+
+  "githubLinkTooltip": {
+    "message": "Fork me on Github!"
+  }
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
 		"page": "options.html",
 		"browser_style": true
 	},
-	"default_locale": "pt_BR",
+	"default_locale": "en",
 	"permissions": [
 		"tabs",
 		"storage"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 2,
-	"name": "L10n Workflow",
-	"description": "Uma maneira mais rápida de acessar os sites utilizados para localizar/traduzir os produtos e projetos da Mozilla para o Português do Brasil.",
+	"name": "__MSG_extensionName__",
+	"description": "__MSG_extensionDescription__",
 	"version": "1.1.0",
 	"homepage_url": "https://github.com/cynthiapereira/webextension-l10n-workflow",
 	"icons": {
@@ -9,7 +9,7 @@
   	},
 	"browser_action": {
 		"browser_style": true,
-		"default_title": "L10n Workflow",
+		"default_title": "__MSG_extensionName__",
 		"default_popup": "tabs.html",
 		"default_icon": {
 			"16": "icons/flag-brazil-32x32.png"
@@ -19,6 +19,7 @@
 		"page": "options.html",
 		"browser_style": true
 	},
+	"default_locale": "pt_BR",
 	"permissions": [
 		"tabs",
 		"storage"

--- a/options.html
+++ b/options.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
 </head>
 <body>
-  <label for="locale">Locale:</label> <input id="locale" type="text" required></input>
+  <label for="locale" data-l10n-id="optionsLocaleLabel"></label> <input id="locale" type="text" required></input>
   <script src="options.js"></script>
 </body>
 </html>

--- a/options.js
+++ b/options.js
@@ -14,3 +14,7 @@ localeInput.addEventListener('change', function(e) {
   options[localeOptionKey] = e.target.value;
   browser.storage.local.set(options);
 });
+
+for (const element of document.querySelectorAll('[data-l10n-id]')) {
+  element.textContent = chrome.i18n.getMessage(element.dataset.l10nId);
+}

--- a/tabs.css
+++ b/tabs.css
@@ -17,6 +17,10 @@ html, body {
 	color: #ebebeb;
 }
 
+.panel .panel-section-body .panel-list-item {
+  cursor: pointer;
+}
+
 .panel .panel-section-body .panel-list-item:hover {
 	background-color: #3f4752;
 }

--- a/tabs.css
+++ b/tabs.css
@@ -24,17 +24,17 @@ html, body {
 	text-decoration: none;
 	display: inline-block;
 }
-.panel .panel-section-body a.default {
+.panel .panel-section-body .default {
 	color: #7bc876;
 }
-.panel .panel-section-body a.glossary {
+.panel .panel-section-body .glossary {
 	color: #4fc4f6;
 }
-.panel .panel-section-body a.dictionary {
+.panel .panel-section-body .dictionary {
 	color: #fed271; 
 }
 
-.panel .panel-section-body a.github {
+.panel .panel-section-body .github {
 	color: #17caae;
 }
 

--- a/tabs.html
+++ b/tabs.html
@@ -8,39 +8,39 @@
   <div class="panel">
     <div class="panel-section panel-section-header">
       <div class="icon-section-header"></div>
-      <div class="text-section-header">L10n Workflow</div>
+      <div class="text-section-header" data-l10n-id="extensionName"></div>
     </div>
     <div class="panel-section-body">
-			<div class="panel-list-item" data-toggle="tooltip" title="Ferramenta de tradução dos produtos e sites da Mozilla">
-				<a href="#" class="default" id="tabs-pontoon"><img class="item_icon" src="icons/logo.svg">Pontoon</a>
+			<div class="panel-list-item default" id="tabs-pontoon" data-toggle="tooltip" data-tooltip-l10n-id="pontoonLinkTooltip">
+				<img class="item_icon" src="icons/logo.svg"><span data-l10n-id="pontoonLinkText"></span>
 			</div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Ferramenta para visualização de como uma expressão foi traduzida em outras strings no Pontoon">
-				<a href="#" class="default" id="tabs-pontoon-terminology"><img class="item_icon" src="icons/logo.svg">Pontoon Terminology</a>
-			</div>
-
-      <div class="panel-section-separator"></div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Ferramenta para visualização de como outros times de l10n traduziram strings">
-				<a href="#" class="glossary" id="tabs-transvision"><img class="item_icon" src="icons/transvision.svg">Transvision</a>
-			</div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Conjunto de termos padrões adotados nas traduções para Português">
-				<a href="#" class="glossary" id="tabs-glossario"><img class="item_icon" src="icons/mozilla-wiki.ico">Glossário</a>
-			</div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Guia de boas práticas de localização adotado pelo time brasileiro">
-				<a href="#" class="glossary" id="tabs-guia-estilos"><img class="item_icon" src="icons/mozilla-wiki.ico">Guia de estilos</a>
+			<div class="panel-list-item default" id="tabs-pontoon-terminology" data-toggle="tooltip" data-tooltip-l10n-id="pontoonTerminologyLinkTooltip">
+				<img class="item_icon" src="icons/logo.svg"><span data-l10n-id="pontoonTerminologyLinkText"></span>
 			</div>
 
       <div class="panel-section-separator"></div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Renomado dicionário Inglês-Português e Português-Inglês">
-				<a href="#" class="dictionary" id="tabs-cambridge"><img class="item_icon" src="icons/cambridge.ico">Cambridge Dictionary</a>
+			<div class="panel-list-item glossary" id="tabs-transvision" data-toggle="tooltip" data-tooltip-l10n-id="transvisionLinkTooltip">
+				<img class="item_icon" src="icons/transvision.svg"><span data-l10n-id="transvisionLinkText"></span>
+			</div>
+			<div class="panel-list-item glossary" id="tabs-glossary" data-toggle="tooltip" data-tooltip-l10n-id="glossaryLinkTooltip">
+				<img class="item_icon" src="icons/mozilla-wiki.ico"><span data-l10n-id="glossaryLinkText"></span>
+			</div>
+			<div class="panel-list-item glossary" id="tabs-style-guide" data-toggle="tooltip" data-tooltip-l10n-id="styleGuideLinkTooltip">
+				<img class="item_icon" src="icons/mozilla-wiki.ico"><span data-l10n-id="styleGuideLinkText"></span>
+			</div>
+
+      <div class="panel-section-separator"></div>
+			<div class="panel-list-item dictionary" id="tabs-cambridge" data-toggle="tooltip" data-tooltip-l10n-id="cambridgeLinkTooltip">
+				<img class="item_icon" src="icons/cambridge.ico"><span data-l10n-id="cambridgeLinkText"></span>
 			</div>
 
 			<div class="panel-section-separator"></div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Visão geral do status de tradução dos projetos da Mozilla">
-				<a href="#" class="dictionary" id="tabs-web-localization-dashboard"><img class="item_icon" src="icons/web-dashboard.png">Web Localization Dashboard</a>
+			<div class="panel-list-item dictionary" id="tabs-web-localization-dashboard" data-toggle="tooltip" data-tooltip-l10n-id="webdashboardLinkTooltip">
+				<img class="item_icon" src="icons/web-dashboard.png"><span data-l10n-id="webdashboardLinkText"></span>
 			</div>
 			<div class="panel-section-separator"><hr></div>
-			<div class="panel-list-item" data-toggle="tooltip" title="Fork me on Github!">
-				<a href="#" class="github" id="tabs-github"><img class="item_icon" src="icons/github.png">Github</a>
+			<div class="panel-list-item github" id="tabs-github" data-toggle="tooltip" data-tooltip-l10n-id="githubLinkTooltip">
+				<img class="item_icon" src="icons/github.png"><span data-l10n-id="githubLinkText"></span>
 			</div>
     </div>
   </div>

--- a/tabs.js
+++ b/tabs.js
@@ -13,37 +13,41 @@ browser.storage.local.get(localeOptionKey).then(function(item) {
 });
 
 document.addEventListener("click", function(e) {
-  if (e.target.id === "tabs-pontoon") {
-    browser.tabs.create({ url: `https://pontoon.mozilla.org/${locale}/` });
+  switch (e.target.id) {
+    case "tabs-pontoon":
+      browser.tabs.create({ url: `https://pontoon.mozilla.org/${locale}/` });
+      break;
+    case "tabs-pontoon-terminology":
+      browser.tabs.create({url: "https://pontoon.mozilla.org/terminology/"});
+      break;
+    case "tabs-transvision":
+      browser.tabs.create({url: "https://transvision.mozfr.org/"});
+      break;
+    case "tabs-glossary":
+      browser.tabs.create({url: "https://wiki.mozilla.org/Brasil/L10n/Glossario"});
+      break;
+    case "tabs-style-guide":
+      browser.tabs.create({url: `https://mozilla-l10n.github.io/styleguides/${locale}/`});
+      break;
+    case "tabs-cambridge":
+      browser.tabs.create({url: `http://dictionary.cambridge.org/${locale.split('-')[0]}/`});
+      break;
+    case "tabs-web-localization-dashboard":
+      browser.tabs.create({url: `https://l10n.mozilla-community.org/webdashboard/?locale=${locale}`});
+      break;
+    case "tabs-github":
+      browser.tabs.create({url: "https://github.com/cynthiapereira/webextension-l10n-workflow"});
+      break;
+    default:
+      e.target.parentNode.click();
+      break;
   }
-
-  else if (e.target.id === "tabs-pontoon-terminology") {
-    browser.tabs.create({url: "https://pontoon.mozilla.org/terminology/"});
-  }
-
-  else if (e.target.id === "tabs-transvision") {
-    browser.tabs.create({url: "https://transvision.mozfr.org/"});
-  }
-
-  else if (e.target.id === "tabs-glossario") {
-    browser.tabs.create({url: "https://wiki.mozilla.org/Brasil/L10n/Glossario"});
-  }
-
-  else if (e.target.id === "tabs-guia-estilos") {
-    browser.tabs.create({url: `https://mozilla-l10n.github.io/styleguides/${locale}/`});
-  }
-
-  else if (e.target.id === "tabs-cambridge") {
-    browser.tabs.create({url: `http://dictionary.cambridge.org/${locale.split('-')[0]}/`});
-  }
-
-  else if (e.target.id === "tabs-web-localization-dashboard") {
-    browser.tabs.create({url: `https://l10n.mozilla-community.org/webdashboard/?locale=${locale}`});
-  }
-
-  else if (e.target.id === "tabs-github") {
-    browser.tabs.create({url: "https://github.com/cynthiapereira/webextension-l10n-workflow"});
-  }
-
-  e.preventDefault();
 });
+
+for (const element of document.querySelectorAll('[data-l10n-id]')) {
+  element.textContent = chrome.i18n.getMessage(element.dataset.l10nId);
+}
+
+for (const element of document.querySelectorAll('[data-tooltip-l10n-id]')) {
+  element.title = chrome.i18n.getMessage(element.dataset.tooltipL10nId);
+}

--- a/tabs.js
+++ b/tabs.js
@@ -8,7 +8,7 @@ browser.storage.local.get(localeOptionKey).then(function(item) {
     locale = 'pt-BR';
   }
   if (locale != 'pt-BR') {
-    document.getElementById('tabs-glossario').parentElement.style.display = 'none';
+    document.getElementById('tabs-glossary').parentElement.style.display = 'none';
   }
 });
 


### PR DESCRIPTION
Here I made all the texts localizable.

The last thing missing is to make also the flag localizable, which I haven't found a reliable way to do so. So far I have tried to `fetch()` a file `icon.png` in the `_locales` subdirectory, but for some reason it fails every time, even if the image is there. I would like to avoid using a separate string to store the icon path... Or what about replacing the flag by the ml10n.jpg image?